### PR TITLE
Actualización de Parroquia Bergantín.

### DIFF
--- a/venezuela.sql
+++ b/venezuela.sql
@@ -970,7 +970,7 @@ INSERT INTO `parroquias` (`id_parroquia`, `id_municipio`, `parroquia`) VALUES
 (70, 25, 'Boca de Chávez'),
 (71, 26, 'Pueblo Nuevo'),
 (72, 26, 'Santa Ana'),
-(73, 27, 'Bergatín'),
+(73, 27, 'Bergantín'),
 (74, 27, 'Caigua'),
 (75, 27, 'El Carmen'),
 (76, 27, 'El Pilar'),


### PR DESCRIPTION
Corrección de Parroquia del Municipio Simón Bolívar, Barcelona - Edo.
Anzoátegui (Bergatín -> Bergantín).